### PR TITLE
Make a proper GNU gettext API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Beta - Version 0.9.4
 // Replace MyApp with your own namespace
 namespace MyApp {
   public class I18n : Mgl.I18n {
-    protected static readonly I18n instance = new I18n();
+    private static readonly I18n _instance = new I18n();
 
     // Customize your languages here
     protected static string[] locales = new string[] {
@@ -41,7 +41,7 @@ namespace MyApp {
 
     public static I18n Instance {
       get {
-        return instance;
+        return _instance;
       }
     }
   }

--- a/src/I18nUnity/Mgl/I18n.cs
+++ b/src/I18nUnity/Mgl/I18n.cs
@@ -9,9 +9,9 @@ namespace Mgl
     {
         private static JSONNode translationData = null;
 
-        protected static readonly I18n instance = new I18n();
-
         protected static string[] locales = new string[] { "en-US", "fr-FR", "es-ES" };
+
+        private static readonly I18n _instance = new I18n();
 
         private static string _currentLocale = "en-US";
 
@@ -32,7 +32,7 @@ namespace Mgl
         {
             get
             {
-                return instance;
+                return _instance;
             }
         }
 
@@ -43,6 +43,9 @@ namespace Mgl
                 string localConfigPath = _localePath + _currentLocale;
                 // Read the file as one string.
                 TextAsset configText = Resources.Load(localConfigPath) as TextAsset;
+                if (!configText) {
+                    throw new Exception("Missing resource file: " + localConfigPath);
+                }
                 translationData = JSON.Parse(configText.text);
             }
             else if (_isLoggingMissing)


### PR DESCRIPTION
This PR adds a proper GNU gettext API interface to allow a further usage through babel.

- [ ] Drop `__(key, *args)` for a simple `gettext(key, *args)`;
- [ ] Add `ngettext(key_singular, key_plural, count, *args)` for numbered `gettext`s.